### PR TITLE
Prevent window flickering when holding Esc

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -975,7 +975,7 @@ void GMainWindow::InitializeHotkeys() {
             &QShortcut::activatedAmbiguously, ui->action_Fullscreen, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Exit Fullscreen"), this),
             &QShortcut::activated, this, [&] {
-                if (emulation_running) {
+                if (emulation_running && ui->action_Fullscreen->isChecked()) {
                     ui->action_Fullscreen->setChecked(false);
                     ToggleFullscreen();
                 }


### PR DESCRIPTION
Reported on discord by Levlight. Don't try to exit fullscreen if it's already off.